### PR TITLE
:bug: 修复共鸣星杖合成

### DIFF
--- a/20220807/scripts/misc.zs
+++ b/20220807/scripts/misc.zs
@@ -25,7 +25,7 @@ mods.thaumcraft.Infusion.registerRecipe("itemwand", "",<astralsorcery:itemwand>,
     <aspect:auram> * 20, <aspect:vacuos> * 50, <aspect:ordo> * 30, <aspect:praecantatio> * 30, <aspect:cognitio> * 100
     ], 
     <botania:twigwand>, [
-        <minecraft:dye:4>, <quark:root_dye:1>, <minecraft:glowstone>, <astralsorcery:itemcraftingcomponent>, <astralsorcery:itemcraftingcomponent:2>, <astralsorcery:itemrockcrystalsimple>, <astralsorcery:itemcraftingcomponent>
+        <minecraft:dye:4>, <quark:glass_shards>, <minecraft:glowstone>, <astralsorcery:itemcraftingcomponent>, <thaumcraft:salis_mundus>, <ic2:dust:6>, <rftools:dimensional_shard>
     ]
 );
 


### PR DESCRIPTION
`<quark:root_dye:1>`黑色染料
`<astralsorcery:itemrockcrystalsimple>`水晶石
`<astralsorcery:itemusabledust>`辉光粉
`<astralsorcery:itemusabledust:1>`暗夜粉
`<astralsorcery:itemcraftingcomponent>`海蓝宝石
`<astralsorcery:itemcraftingcomponent:2>`星尘
`<astralsorcery:itemcraftingcomponent:3>`玻璃透镜
`<quark:glass_shards>`玻璃碎片
`<thaumcraft:salis_mundus>`世界盐
`<ic2:dust:6>`能量水晶粉
`<rftools:dimensional_shard>`维度碎片

删去了很难得到的夸克黑色染料，添加了玻璃碎片、世界盐、能量水晶粉、维度碎片（合成或下界、地狱挖掘得到）。